### PR TITLE
Fixed bug with pd.Series

### DIFF
--- a/outliers/smirnov_grubbs.py
+++ b/outliers/smirnov_grubbs.py
@@ -150,7 +150,10 @@ class TwoSidedGrubbsTest(GrubbsTest):
         mean
         """
         relative_values = abs(data - data.mean())
-        index = relative_values.argmax()
+        if isinstance(relative_values, pd.Series):
+            index = relative_values.idxmax()
+        else:
+            index = relative_values.argmax()
         value = relative_values[index]
         return index, value
 


### PR DESCRIPTION
i.e. the two side test for pd.Series([1, 8, 10, 9, 10, 100, 9, 10, 11]) will fail without this change when the target is dropped.

